### PR TITLE
Apache config file in wrong location

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -79,7 +79,7 @@
 - name: Enable the httpd frontend
   template: >-
     src=webfrontend-apache.conf.j2
-    dest={{ httpd_conf_d_dir }}
+    dest={{ httpd_conf_d_dir }}/ganglia.conf
     owner=root
     group=root
     mode=0644


### PR DESCRIPTION
The `webfronted-apache.conf.j2` template is being installed to `/etc/httpd/conf.d/webfrontend-apache.conf.j2`, which seems to be wrong.
